### PR TITLE
Do not depend on react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "touchid",
     "passwordless"
   ],
-  "dependencies": {
-    "react-native": "^0.15.0"
+  "peerDependencies": {
+    "react-native": "^0.16.0"
   },
   "author": "Auth0",
   "license": "MIT",


### PR DESCRIPTION
If react-native is installed as a dependency it will conflict with the user project's react-native and produce duplicated files/functions conflicts
Also when creating a new project react-native uses the latest version, and this package depends on an older version. They are already on v0.16
