### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "touchid",
     "passwordless"
   ],
-  "peerDependencies": {
-    "react-native": "^0.17.0"
-  },
   "author": "Auth0",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Tested & works on the latest `react-native`.

Fixes https://github.com/auth0/react-native-lock-android/issues/8 as well.
